### PR TITLE
Store session in keychain to refresh tokens

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,7 @@ setup(
         'boto3',
         'click',
         'future',
+        'keyring',
         'requests',
         'six',
     ],


### PR DESCRIPTION
This change saves the lastpass session in the keychain and allows you to reuse an active lastpass session to get the saml token.